### PR TITLE
fixed steps: push-dockerhub, unit-tests

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -29,24 +29,25 @@
     unit tests:
       image: node:6.3.0-onbuild
       commands:
-         - npm install
+         - gulp tslint
+         - npm -v
       description: codefresh example
 
-    notify:
-      image: verchol/slack:latest
-      environment:
-        - MESSAGE="build for comit ${{CF_BRANCH}}-${{CF_REVISION}}"
-      commands:
-          - echo $MESSAGE
-          - sh /scripts/slack.sh
-
-      description: codefresh example
-
-
-      deploy:
-        image: verchol/slack:latest
-        commands:
-              - echo $MESSAGE
-              - sh /scripts/slack.sh
-
-        description: codefresh example
+#    notify:
+#      image: verchol/slack:latest
+#      environment:
+#        - MESSAGE="build for comit ${{CF_BRANCH}}-${{CF_REVISION}}"
+#      commands:
+#          - echo $MESSAGE
+#          - sh /scripts/slack.sh
+#
+#      description: codefresh example
+#
+#
+#      deploy:
+#        image: verchol/slack:latest
+#        commands:
+#              - echo $MESSAGE
+#              - sh /scripts/slack.sh
+#
+#        description: codefresh example

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -20,10 +20,10 @@
       #  password:
 
 
-    #push-dockerhub:
-     #type: push
-     #candidate: ${{build-prj}}
-     #tag: awesomeness
+    push-dockerhub:
+     type: push
+     candidate: ${{build-image}}
+     tag: ${{CF_BRANCH}}
 
 
     unit tests:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -29,7 +29,7 @@
     unit tests:
       image: node:6.3.0-onbuild
       commands:
-         - npm install -g gulp; echo running unit tests; gulp tslint
+         - npm install
       description: codefresh example
 
     notify:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -29,8 +29,9 @@
     unit tests:
       image: node:6.3.0-onbuild
       commands:
-         - gulp tslint
-         - npm -v
+        - npm install
+        - gulp tslint
+        - npm -v
       description: codefresh example
 
 #    notify:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -6,7 +6,7 @@
     build-image:
       type: build
       description: angular example
-      image-name: verchol/angular2-todo
+      image-name: ncodefresh/angular2-todo
       dockerfile: Dockerfile
       tag: ${{CF_BRANCH}}
 

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -30,7 +30,7 @@
       image: node:6.3.0-onbuild
         #codefresh/angular2-todo:${{CF_BRANCH}}
       commands:
-         - npm install -g gulp
+         - npm install gulp
          - echo running unit tests
          - gulp tslint
          #- curl http://18391060.ngrok.io

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -30,7 +30,7 @@
       image: node:6.3.0-onbuild
       commands:
         - npm install
-        - gulp tslint
+        - npm test
         - npm -v
       description: codefresh example
 

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,7 +27,7 @@
 
 
     unit tests:
-      image: ncodefresh/nodeall
+      image: ncodefresh/nodeall:latest
       #node:6.3.0-onbuild
         #codefresh/angular2-todo:${{CF_BRANCH}}
       commands:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -28,13 +28,8 @@
 
     unit tests:
       image: node:6.3.0-onbuild
-        #codefresh/angular2-todo:${{CF_BRANCH}}
       commands:
-         - npm install
-         - echo running unit tests
-         - gulp tslint
-         #- curl http://18391060.ngrok.io
-        # - curl -X POST -H \'Content-type: application/json\' --data \'{"text":"This is a line of text.\nAnd this is another one."}\'  https://hooks.slack.com/services/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
+         - npm install -g gulp; echo running unit tests; gulp tslint
       description: codefresh example
 
     notify:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,11 +27,10 @@
 
 
     unit tests:
-      image: ncodefresh/nodeall:latest
-      #node:6.3.0-onbuild
+      image: node:6.3.0-onbuild
         #codefresh/angular2-todo:${{CF_BRANCH}}
       commands:
-         #- npm install gulp
+         - npm install
          - echo running unit tests
          - gulp tslint
          #- curl http://18391060.ngrok.io

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,10 +27,11 @@
 
 
     unit tests:
-      image: node:6.3.0-onbuild
+      image: ncodefresh/nodeall
+      #node:6.3.0-onbuild
         #codefresh/angular2-todo:${{CF_BRANCH}}
       commands:
-         - npm install gulp
+         #- npm install gulp
          - echo running unit tests
          - gulp tslint
          #- curl http://18391060.ngrok.io

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "rxjs": "5.0.0-beta.0",
     "systemjs": "0.19.6",
     "zone.js": "0.5.10"
+  },
+  "scripts": {
+    "test": "gulp tslint"
   }
 }


### PR DESCRIPTION
Need change in the field "image-name" the repoOwner on your

``` yml
build-image:
      type: build
      description: angular example
      image-name: ncodefresh/angular2-todo
```

For the step "push-dockerhub" should be provide correct credentials on the page "Account management->Integration->Dockerhub"

The step "unit-test' works when using commands in one line

``` yml
unit tests:
      image: node:6.3.0-onbuild
      commands:
         - npm install -g gulp; echo running unit tests; gulp tslint
      description: codefresh example
```
